### PR TITLE
Disable react/no-did-update-set-state

### DIFF
--- a/packages/eslint-config-react/rules/custom.js
+++ b/packages/eslint-config-react/rules/custom.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
     "jsx-a11y/img-has-alt": 0,
+    "react/no-did-update-set-state": "off",
   },
 };


### PR DESCRIPTION
Tara suggested we disable this, as `componentDidUpdate` can have `setState` in it, but it has to be conditional, to avoid infinite loops.

This is also being suggested on the [eslint-plugin-react GitHub in an issue](https://github.com/yannickcr/eslint-plugin-react/issues/1707).