### PR TITLE
Add arrowParens: avoid

### DIFF
--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/eslint-config-base",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Shoutem's base JS ESlint config",
   "main": "index.js",
   "author": "Shoutem",

--- a/packages/eslint-config-base/rules/prettier.js
+++ b/packages/eslint-config-base/rules/prettier.js
@@ -5,6 +5,7 @@ module.exports = {
       {
         singleQuote: true,
         trailingComma: "all",
+        arrowParens: "avoid",
       },
       {
         usePrettierrc: false,


### PR DESCRIPTION
`avoid` will no longer be default value, so the rule has to be specified

![image](https://user-images.githubusercontent.com/57353746/135829173-b331238e-7e61-4c2c-8d72-d3db38ff833a.png)
