### PR TITLE
Add react native config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Shoutem JavaScript Style Guide
 
-This repository provides two eslint packages:
+This repository provides three eslint packages:
 
 1. [eslint-config-base](https://github.com/shoutem/eslint-config/tree/develop/packages/eslint-config-base)
 2. [eslint-config-react](https://github.com/shoutem/eslint-config/tree/develop/packages/eslint-config-react)
+3. [eslint-config-react-native](https://github.com/shoutem/eslint-config/tree/develop/packages/eslint-config-react-native)
 
 ## Automatically Fix Code in VS Code
 

--- a/packages/eslint-config-base/README.md
+++ b/packages/eslint-config-base/README.md
@@ -1,6 +1,6 @@
 # @shoutem/eslint-config-base
 
-[![npm version](https://badge.fury.io/js/@shoutem/eslint-config-base.svg)](http://badge.fury.io/js/@shoutem/eslint-config-base)
+[![npm version](https://badge.fury.io/js/@shoutem%2Feslint-config-base.svg)](https://badge.fury.io/js/@shoutem%2Feslint-config-base)
 
 This package provides Shoutem's base JS .eslintrc (without React plugins) as an extensible shared config.
 

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/eslint-config-base",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Shoutem's base JS ESlint config",
   "main": "index.js",
   "author": "Shoutem",
   "license": "MIT",
   "dependencies": {
-    "eslint-config-airbnb-base": "^3.0.0",
+    "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^6.10.0"
   },
   "peerDependencies": {

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -6,7 +6,7 @@
   "author": "Shoutem",
   "license": "MIT",
   "dependencies": {
-    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-config-airbnb-base": "^3.0.0",
     "eslint-config-prettier": "^6.10.0"
   },
   "peerDependencies": {

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -6,12 +6,12 @@
   "author": "Shoutem",
   "license": "MIT",
   "dependencies": {
-    "eslint-config-airbnb-base": "^3.0.0",
+    "eslint-config-airbnb-base": "14.0.0",
     "eslint-config-prettier": "^6.10.0"
   },
   "peerDependencies": {
     "eslint": "^6.8.0",
-    "eslint-plugin-import": "^2.20.1",
+    "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-prettier": "3.1.3",
     "prettier": "1.19.1"
   },

--- a/packages/eslint-config-react-native/README.md
+++ b/packages/eslint-config-react-native/README.md
@@ -1,0 +1,30 @@
+# @shoutem/eslint-config
+
+[![npm version](https://badge.fury.io/js/@shoutem%2Feslint-config-react-native.svg)](https://badge.fury.io/js/@shoutem%2Feslint-config-react-native)
+
+This package provides Shoutem's React Native JS .eslintrc (with React plugins) as an extensible shared config.
+
+## Usage
+
+Our default export contains all of our ESLint rules, including ECMAScript 6+. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-prettier`, `eslint-plugin-simple-import-sort`, `eslint-plugin-jsx-a11y`, `eslint-plugin-react`, `eslint-plugin-react-native`, `eslint-plugin-react-hooks` and `prettier`.
+
+1. Install the correct versions of each package, which are listed by the command:
+
+```sh
+npm info "@shoutem/eslint-config-react@latest" peerDependencies
+```
+
+If using **npm 5+**, use this shortcut
+
+```sh
+npx install-peerdeps --dev @shoutem/eslint-config-react-native
+```
+
+If using **npm < 5**, you can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
+
+```sh
+npm install -g install-peerdeps
+install-peerdeps --dev @shoutem/eslint-config-react-native
+```
+
+2. Add `"extends": "@shoutem/react-native"` to your .eslintrc.

--- a/packages/eslint-config-react-native/README.md
+++ b/packages/eslint-config-react-native/README.md
@@ -1,4 +1,4 @@
-# @shoutem/eslint-config
+# @shoutem/eslint-config-react-native
 
 [![npm version](https://badge.fury.io/js/@shoutem%2Feslint-config-react-native.svg)](https://badge.fury.io/js/@shoutem%2Feslint-config-react-native)
 
@@ -11,7 +11,7 @@ Our default export contains all of our ESLint rules, including ECMAScript 6+. It
 1. Install the correct versions of each package, which are listed by the command:
 
 ```sh
-npm info "@shoutem/eslint-config-react@latest" peerDependencies
+npm info "@shoutem/eslint-config-react-native@latest" peerDependencies
 ```
 
 If using **npm 5+**, use this shortcut

--- a/packages/eslint-config-react-native/index.js
+++ b/packages/eslint-config-react-native/index.js
@@ -1,0 +1,21 @@
+module.exports = {
+  extends: [
+    "airbnb",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
+    "@shoutem/react",
+    // custom rules
+    require.resolve("./rules/custom"),
+  ],
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: "module",
+  },
+  plugins: [
+    "react",
+    "react-native",
+    "import",
+    "simple-import-sort"
+  ],
+  rules: {},
+};

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@shoutem/eslint-config-react-native",
+  "version": "1.0.0",
+  "description": "Shoutem's React Native JS ESlint config",
+  "main": "index.js",
+  "author": "Shoutem",
+  "license": "MIT",
+  "dependencies": {
+    "@shoutem/eslint-config-base": "^1.0.1",
+    "@shoutem/eslint-config-react": "^1.0.1",
+    "eslint-config-airbnb": "^18.2.1"
+  },
+  "peerDependencies": {
+    "eslint": "^6.8.0",
+    "eslint-plugin-import": "^2.20.1",
+    "eslint-plugin-jsx-a11y": "^1.3.0",
+    "eslint-plugin-prettier": "3.1.3",
+    "eslint-plugin-react": "^5.1.1",
+    "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-react-native": "^3.11.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
+    "prettier": "1.19.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shoutem/eslint-config"
+  },
+  "keywords": [
+    "eslint",
+    "eslint-config",
+    "prettier",
+    "shoutem"
+  ],
+  "bugs": {
+    "url": "https://github.com/shoutem/eslint-config/issues"
+  },
+  "homepage": "https://github.com/shoutem/eslint-config#readme"
+}

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@shoutem/eslint-config-base": "^1.0.1",
     "@shoutem/eslint-config-react": "^1.0.1",
-    "eslint-config-airbnb": "^18.2.1"
+    "eslint-config-airbnb": "^9.0.1"
   },
   "peerDependencies": {
     "eslint": "^6.8.0",

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@shoutem/eslint-config-base": "^1.0.1",
     "@shoutem/eslint-config-react": "^1.0.1",
-    "eslint-config-airbnb": "^9.0.1"
+    "eslint-config-airbnb": "18.2.1"
   },
   "peerDependencies": {
     "eslint": "^6.8.0",

--- a/packages/eslint-config-react-native/rules/custom.js
+++ b/packages/eslint-config-react-native/rules/custom.js
@@ -1,0 +1,8 @@
+module.exports = {
+  rules: {
+    "react-native/no-unused-styles": 2,
+    "react-native/no-inline-styles": 2,
+    "react-native/no-raw-text": 1,
+    "react-native/no-single-element-style-arrays": 2,
+  },
+};

--- a/packages/eslint-config-react-native/rules/custom.js
+++ b/packages/eslint-config-react-native/rules/custom.js
@@ -4,5 +4,6 @@ module.exports = {
     "react-native/no-inline-styles": 2,
     "react-native/no-raw-text": 1,
     "react-native/no-single-element-style-arrays": 2,
+    "react/jsx-filename-extension": [1, { "extensions": [".js"] }]
   },
 };

--- a/packages/eslint-config-react/README.md
+++ b/packages/eslint-config-react/README.md
@@ -1,12 +1,12 @@
 # @shoutem/eslint-config
 
-[![npm version](https://badge.fury.io/js/@shoutem/eslint-config-react.svg)](http://badge.fury.io/js/@shoutem/eslint-config-react)
+[![npm version](https://badge.fury.io/js/@shoutem%2Feslint-config-react.svg)](https://badge.fury.io/js/@shoutem%2Feslint-config-react)
 
-This package provides Shoutem's react JS .eslintrc (with React plugins) as an extensible shared config.
+This package provides Shoutem's React JS .eslintrc (with React plugins) as an extensible shared config.
 
 ## Usage
 
-Our default export contains all of our ESLint rules, including ECMAScript 6+. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-prettier`, `eslint-plugin-jsx-a11y`, `eslint-plugin-react`, `eslint-plugin-react-hooks` and `prettier`.
+Our default export contains all of our ESLint rules, including ECMAScript 6+. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-prettier`, `eslint-plugin-import`, `eslint-plugin-simple-import-sort`, `eslint-plugin-jsx-a11y`, `eslint-plugin-react`, `eslint-plugin-react-hooks` and `prettier`.
 
 1. Install the correct versions of each package, which are listed by the command:
 

--- a/packages/eslint-config-react/README.md
+++ b/packages/eslint-config-react/README.md
@@ -1,4 +1,4 @@
-# @shoutem/eslint-config
+# @shoutem/eslint-config-react
 
 [![npm version](https://badge.fury.io/js/@shoutem%2Feslint-config-react.svg)](https://badge.fury.io/js/@shoutem%2Feslint-config-react)
 

--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: [
     "airbnb",
+    "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "@shoutem/base",
     // custom rules
@@ -10,5 +11,10 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: "module",
   },
+  plugins: [
+    "react",
+    "import",
+    "simple-import-sort"
+  ],
   rules: {},
 };

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "@shoutem/eslint-config-base": "^1.0.1",
-    "eslint-config-airbnb": "^9.0.1"
+    "eslint-config-airbnb": "18.2.1"
   },
   "peerDependencies": {
     "eslint": "^6.8.0",

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "@shoutem/eslint-config-base": "^1.0.1",
-    "eslint-config-airbnb": "^18.2.1"
+    "eslint-config-airbnb": "^9.0.1"
   },
   "peerDependencies": {
     "eslint": "^6.8.0",

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,21 +1,22 @@
 {
   "name": "@shoutem/eslint-config-react",
-  "version": "1.0.2",
-  "description": "Shoutem's react JS ESlint config",
+  "version": "1.0.3",
+  "description": "Shoutem's React JS ESlint config",
   "main": "index.js",
   "author": "Shoutem",
   "license": "MIT",
   "dependencies": {
     "@shoutem/eslint-config-base": "^1.0.1",
-    "eslint-config-airbnb": "^9.0.1"
+    "eslint-config-airbnb": "^18.2.1"
   },
   "peerDependencies": {
     "eslint": "^6.8.0",
-    "eslint-plugin-import": "^2.20.1",
+    "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-jsx-a11y": "^1.3.0",
     "eslint-plugin-prettier": "3.1.3",
-    "eslint-plugin-react": "^5.1.1",
+    "eslint-plugin-react": "^7.20.5",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "prettier": "1.19.1"
   },
   "repository": {

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -12,9 +12,9 @@
   "peerDependencies": {
     "eslint": "^6.8.0",
     "eslint-plugin-import": "^2.24.2",
-    "eslint-plugin-jsx-a11y": "^1.3.0",
+    "eslint-plugin-jsx-a11y": "^6.4.0",
     "eslint-plugin-prettier": "3.1.3",
-    "eslint-plugin-react": "^7.20.5",
+    "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "prettier": "1.19.1"

--- a/packages/eslint-config-react/rules/custom.js
+++ b/packages/eslint-config-react/rules/custom.js
@@ -9,7 +9,7 @@ module.exports = {
       {
         "groups": [
           [
-             // Packages. `react` related packages come first.
+            // Packages. `react` related packages come first.
             "^react",
             // Internal packages.
             "^(@|@shoutem)(\/.*|$)",

--- a/packages/eslint-config-react/rules/custom.js
+++ b/packages/eslint-config-react/rules/custom.js
@@ -2,5 +2,31 @@ module.exports = {
   rules: {
     "jsx-a11y/img-has-alt": 0,
     "react/no-did-update-set-state": "off",
+    "react/require-default-props": 2,
+    "simple-import-sort/exports": "error",
+    "simple-import-sort/imports": [
+      "error",
+      {
+        "groups": [
+          [
+             // Packages. `react` related packages come first.
+            "^react",
+            // Internal packages.
+            "^(@|@shoutem)(\/.*|$)",
+            // Side effect imports.
+            "^\\u0000",
+            // Parent imports. Put `..` last.
+            "^\\.\\.(?!/?$)",
+            "^\\.\\./?$",
+            // Other relative imports. Put same-folder imports and `.` last.
+            "^\\./(?=.*/)(?!/?$)",
+            "^\\.(?!/?$)",
+            "^\\./?$",
+            // Style imports
+            "^.+\\.s?css$"
+          ]
+        ]
+      }
+    ],
   },
 };

--- a/packages/eslint-config-react/rules/custom.js
+++ b/packages/eslint-config-react/rules/custom.js
@@ -1,6 +1,7 @@
 module.exports = {
   rules: {
     "jsx-a11y/img-has-alt": 0,
+    "no-use-before-define": 0,
     "react/no-did-update-set-state": "off",
     "react/require-default-props": 2,
     "simple-import-sort/exports": "error",


### PR DESCRIPTION
Feature adds updates to base & react config, as well as addition of react-native config. 
Wasn't sure if I should bump minor versions instead of patch version.

For React I've added import sorting rules, and default props required.

For React Native I've added 4 rules:
-  `no-unused-styles`: error,
- `no-inline-styles`: error
- `no-raw-text` (outside Text component): warning
- `no-single-element-style-arrays`: error

I'd love to update airbnb config versions as well, since we are 10+ versions behind and there are deprecation warnings when running lint. (Haven't fully checked their changelog yet to know what are major changes)