### PR TITLE
React config fixes

### DIFF
--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -1,21 +1,21 @@
 {
   "name": "@shoutem/eslint-config-react-native",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Shoutem's React Native JS ESlint config",
   "main": "index.js",
   "author": "Shoutem",
   "license": "MIT",
   "dependencies": {
-    "@shoutem/eslint-config-base": "^1.0.1",
-    "@shoutem/eslint-config-react": "^1.0.1",
+    "@shoutem/eslint-config-base": "^1.0.3",
+    "@shoutem/eslint-config-react": "^1.0.3",
     "eslint-config-airbnb": "18.2.1"
   },
   "peerDependencies": {
     "eslint": "^6.8.0",
-    "eslint-plugin-import": "^2.20.1",
-    "eslint-plugin-jsx-a11y": "^1.3.0",
+    "eslint-plugin-import": "^2.24.2",
+    "eslint-plugin-jsx-a11y": "^6.4.0",
     "eslint-plugin-prettier": "3.1.3",
-    "eslint-plugin-react": "^5.1.1",
+    "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-react-native": "^3.11.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "@shoutem/eslint-config-base": "^1.0.3",
-    "@shoutem/eslint-config-react": "^1.0.3",
+    "@shoutem/eslint-config-react": "^1.0.4",
     "eslint-config-airbnb": "18.2.1"
   },
   "peerDependencies": {

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/eslint-config-react",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Shoutem's React JS ESlint config",
   "main": "index.js",
   "author": "Shoutem",

--- a/packages/eslint-config-react/rules/custom.js
+++ b/packages/eslint-config-react/rules/custom.js
@@ -2,8 +2,17 @@ module.exports = {
   rules: {
     "jsx-a11y/img-has-alt": 0,
     "no-use-before-define": 0,
+    "import/order": "off",
+    "import/no-extraneous-dependencies": 0,
     "react/no-did-update-set-state": "off",
     "react/require-default-props": 2,
+    "react/forbid-prop-types": 0,
+    "react/static-property-placement": 0,
+    "react/sort-comp": 0,
+    "react/jsx-filename-extension": [1, { "extensions": [".jsx"] }],
+    "react/jsx-props-no-spreading": 0,
+    "react/jsx-one-expression-per-line": 0,
+    "react/jsx-no-bind": 0,
     "simple-import-sort/exports": "error",
     "simple-import-sort/imports": [
       "error",
@@ -12,8 +21,11 @@ module.exports = {
           [
             // Packages. `react` related packages come first.
             "^react",
+            // Packages
+            "^(?!(shoutem).*)|(@?\\w)$",
             // Internal packages.
-            "^(@|@shoutem)(\/.*|$)",
+            "^(@+shoutem)(\/.*|$)",
+            "^(shoutem)(\.*|$)",
             // Side effect imports.
             "^\\u0000",
             // Parent imports. Put `..` last.


### PR DESCRIPTION
Feature updates peer deps versions to make them compatible with other packages.

Added few new rules to React config which override default airbnb ones to maintain our code conventions. 

Fixed import sorting for shoutem specific imports (eg. `@shoutem/ui` should be before `shoutem.auth`).