### PR TITLE
Add prop types sorting

### DIFF
--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@shoutem/eslint-config-react-native",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Shoutem's React Native JS ESlint config",
   "main": "index.js",
   "author": "Shoutem",
   "license": "MIT",
   "dependencies": {
     "@shoutem/eslint-config-base": "^1.0.3",
-    "@shoutem/eslint-config-react": "^1.0.4",
+    "@shoutem/eslint-config-react": "^1.0.5",
     "eslint-config-airbnb": "18.2.1"
   },
   "peerDependencies": {

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/eslint-config-react",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Shoutem's React JS ESlint config",
   "main": "index.js",
   "author": "Shoutem",

--- a/packages/eslint-config-react/rules/custom.js
+++ b/packages/eslint-config-react/rules/custom.js
@@ -3,6 +3,10 @@ module.exports = {
     "jsx-a11y/img-has-alt": 0,
     "jsx-a11y/control-has-associated-label": 0,
     "no-use-before-define": 0,
+    "no-restricted-globals": 0,
+    "prefer-const": ["warn", {
+      "ignoreReadBeforeAssign": true
+    }],
     "import/order": "off",
     "import/extensions": 0,
     "import/no-extraneous-dependencies": 0,

--- a/packages/eslint-config-react/rules/custom.js
+++ b/packages/eslint-config-react/rules/custom.js
@@ -1,8 +1,10 @@
 module.exports = {
   rules: {
     "jsx-a11y/img-has-alt": 0,
+    "jsx-a11y/control-has-associated-label": 0,
     "no-use-before-define": 0,
     "import/order": "off",
+    "import/extensions": 0,
     "import/no-extraneous-dependencies": 0,
     "react/no-did-update-set-state": "off",
     "react/require-default-props": 2,
@@ -13,6 +15,13 @@ module.exports = {
     "react/jsx-props-no-spreading": 0,
     "react/jsx-one-expression-per-line": 0,
     "react/jsx-no-bind": 0,
+    "react/sort-prop-types": [1, {
+      "callbacksLast": true,
+      "ignoreCase": true,
+      "requiredFirst": true,
+      "sortShapeProp": true,
+      "noSortAlphabetically": false
+    }],
     "simple-import-sort/exports": "error",
     "simple-import-sort/imports": [
       "error",

--- a/packages/eslint-config-react/rules/custom.js
+++ b/packages/eslint-config-react/rules/custom.js
@@ -11,7 +11,7 @@ module.exports = {
     "react/forbid-prop-types": 0,
     "react/static-property-placement": 0,
     "react/sort-comp": 0,
-    "react/jsx-filename-extension": [1, { "extensions": [".jsx"] }],
+    "react/jsx-filename-extension": [1, { "extensions": [".jsx", ".js"] }],
     "react/jsx-props-no-spreading": 0,
     "react/jsx-one-expression-per-line": 0,
     "react/jsx-no-bind": 0,


### PR DESCRIPTION
Feature adds sort prop types rule, as well as few overrides for default airbnb rules that aren't a good fit for our code conventions.

Prop types sorting rules are:
- required props first
- other/nonrequired props
- handlers starting with `on`

Within each group, props should be sorted alphabetically.

Note: prop types sorting cannot be solved with autofix/format on save, and needs to be sorted manually.