### PR TITLE
Disable `label-has-associated-control`

### DIFF
--- a/packages/eslint-config-react/rules/custom.js
+++ b/packages/eslint-config-react/rules/custom.js
@@ -2,6 +2,7 @@ module.exports = {
   rules: {
     "jsx-a11y/img-has-alt": 0,
     "jsx-a11y/control-has-associated-label": 0,
+    "jsx-a11y/label-has-associated-control": 0,
     "no-use-before-define": 0,
     "no-restricted-globals": 0,
     "prefer-const": ["warn", {


### PR DESCRIPTION
Similar to how we've disabled `control-has-associated-label`, feature disables [`label-has-associated-control`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md) because we rarely write labels with controls.