### PR TITLE
Update base config rules

### DIFF
--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/eslint-config-base",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Shoutem's base JS ESlint config",
   "main": "index.js",
   "author": "Shoutem",

--- a/packages/eslint-config-base/rules/custom.js
+++ b/packages/eslint-config-base/rules/custom.js
@@ -18,6 +18,13 @@ module.exports = {
     "no-unused-expressions": 0,
     "no-param-reassign": [2, { props: false }],
     "no-unused-vars": [2, { argsIgnorePattern: "next" }],
+    "no-restricted-syntax": 0,
+    "no-continue": 0,
+    "no-await-in-loop": 0,
+    "no-restricted-globals": 0,
+    "no-buffer-constructor": 0,
+    "max-classes-per-file": 0,
+    "prefer-destructuring": 0,
     "no-shadow": 0,
     "no-plusplus": "off",
     "no-implicit-coercion": [

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/eslint-config-react",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Shoutem's React JS ESlint config",
   "main": "index.js",
   "author": "Shoutem",

--- a/packages/eslint-config-react/rules/custom.js
+++ b/packages/eslint-config-react/rules/custom.js
@@ -10,6 +10,7 @@ module.exports = {
     "import/order": "off",
     "import/extensions": 0,
     "import/no-extraneous-dependencies": 0,
+    "prefer-destructuring": 2,
     "react/no-did-update-set-state": "off",
     "react/require-default-props": 2,
     "react/forbid-prop-types": 0,


### PR DESCRIPTION
In agreement with @damirjuretic , feature updates base config rules.
Additionally, I added `"prefer-destructuring": 2/"error"` in React config to make sure rule isn't disabled in React/React Native. (that was the default rule we are using currently)