### PR TITLE
Add globals to react config

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -17,4 +17,7 @@ module.exports = {
     "simple-import-sort"
   ],
   rules: {},
+  globals: {
+    "fetch": "readonly"
+  },
 };

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/eslint-config-react",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Shoutem's React JS ESlint config",
   "main": "index.js",
   "author": "Shoutem",


### PR DESCRIPTION
Feature adds `fetch` to `globals` config to prevent use of `fetch` triggering [no-undef rule](https://eslint.org/docs/rules/no-undef).