### PR TITLE
Update rules and deps versions

### DIFF
--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -11,7 +11,7 @@
   },
   "peerDependencies": {
     "eslint": "6.8.0",
-    "eslint-plugin-import": "2.24.2",
+    "eslint-plugin-import": "2.25.4",
     "eslint-plugin-prettier": "3.1.3",
     "prettier": "1.19.1"
   },

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@shoutem/eslint-config-base",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Shoutem's base JS ESlint config",
   "main": "index.js",
   "author": "Shoutem",
   "license": "MIT",
   "dependencies": {
     "eslint-config-airbnb-base": "14.0.0",
-    "eslint-config-prettier": "^6.10.0"
+    "eslint-config-prettier": "6.10.1"
   },
   "peerDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-plugin-import": "^2.25.2",
+    "eslint": "6.8.0",
+    "eslint-plugin-import": "2.24.2",
     "eslint-plugin-prettier": "3.1.3",
     "prettier": "1.19.1"
   },

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -1,24 +1,24 @@
 {
   "name": "@shoutem/eslint-config-react-native",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Shoutem's React Native JS ESlint config",
   "main": "index.js",
   "author": "Shoutem",
   "license": "MIT",
   "dependencies": {
     "@shoutem/eslint-config-base": "^1.0.3",
-    "@shoutem/eslint-config-react": "^1.0.5",
+    "@shoutem/eslint-config-react": "^1.0.8",
     "eslint-config-airbnb": "18.2.1"
   },
   "peerDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-plugin-import": "^2.24.2",
-    "eslint-plugin-jsx-a11y": "^6.4.0",
+    "eslint": "6.8.0",
+    "eslint-plugin-import": "2.24.2",
+    "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-prettier": "3.1.3",
-    "eslint-plugin-react": "^7.21.5",
-    "eslint-plugin-react-hooks": "^4.2.0",
-    "eslint-plugin-react-native": "^3.11.0",
-    "eslint-plugin-simple-import-sort": "^7.0.0",
+    "eslint-plugin-react": "7.21.5",
+    "eslint-plugin-react-hooks": "4.2.1",
+    "eslint-plugin-react-native": "3.11.0",
+    "eslint-plugin-simple-import-sort": "7.0.0",
     "prettier": "1.19.1"
   },
   "repository": {

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/eslint-config-react",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Shoutem's React JS ESlint config",
   "main": "index.js",
   "author": "Shoutem",
@@ -10,13 +10,13 @@
     "eslint-config-airbnb": "18.2.1"
   },
   "peerDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-plugin-import": "^2.24.2",
-    "eslint-plugin-jsx-a11y": "^6.4.0",
+    "eslint": "6.8.0",
+    "eslint-plugin-import": "2.24.2",
+    "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-prettier": "3.1.3",
-    "eslint-plugin-react": "^7.21.5",
-    "eslint-plugin-react-hooks": "^4.2.0",
-    "eslint-plugin-simple-import-sort": "^7.0.0",
+    "eslint-plugin-react": "7.21.5",
+    "eslint-plugin-react-hooks": "4.2.1",
+    "eslint-plugin-simple-import-sort": "7.0.0",
     "prettier": "1.19.1"
   },
   "repository": {

--- a/packages/eslint-config-react/rules/custom.js
+++ b/packages/eslint-config-react/rules/custom.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
+    "camelcase": ["error", { allow: ["^UNSAFE_"] }],
     "jsx-a11y/img-has-alt": 0,
     "jsx-a11y/control-has-associated-label": 0,
     "jsx-a11y/label-has-associated-control": 0,
@@ -15,7 +16,7 @@ module.exports = {
     "react/no-did-update-set-state": "off",
     "react/require-default-props": 2,
     "react/forbid-prop-types": 0,
-    "react/static-property-placement": 0,
+    "react/static-property-placement": ["warn", "property assignment"],
     "react/sort-comp": 0,
     "react/jsx-filename-extension": [1, { "extensions": [".jsx", ".js"] }],
     "react/jsx-props-no-spreading": 0,


### PR DESCRIPTION
Feature updates 2 rules:
- `camelcase`: doesn't mark eg. `UNSAFE_componentWillUnmount` as incorrect
- `react/static-property-placement`: forces all static properties to be defined outside of component eg. `static propTypes` will be marked as incorrect

Other than that, I adjusted all dependencies version using semver calc and removed ^.