### PR TITLE
Add UI components to skip no-raw-text rule

### DIFF
--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/eslint-config-react-native",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Shoutem's React Native JS ESlint config",
   "main": "index.js",
   "author": "Shoutem",

--- a/packages/eslint-config-react-native/rules/custom.js
+++ b/packages/eslint-config-react-native/rules/custom.js
@@ -2,7 +2,7 @@ module.exports = {
   rules: {
     "react-native/no-unused-styles": 2,
     "react-native/no-inline-styles": 2,
-    "react-native/no-raw-text": 1,
+    "react-native/no-raw-text": [1, { "skip": ["Caption", "Heading", "Subtitle", "Title"] }],
     "react-native/no-single-element-style-arrays": 2,
     "react/jsx-filename-extension": [1, { "extensions": [".js"] }]
   },


### PR DESCRIPTION
Feature adds shoutem/UI text components to skip option of no-raw-text to prevent false warnings from this rule. All added components are using Text component directly with different styling.