### PR TITLE
Feature/adjust peer deps

### DIFF
--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -10,10 +10,10 @@
     "eslint-config-prettier": "6.10.1"
   },
   "peerDependencies": {
-    "eslint": "6.8.0",
-    "eslint-plugin-import": "2.25.4",
-    "eslint-plugin-prettier": "3.1.3",
-    "prettier": "1.19.1"
+    "eslint": "^6.8.0",
+    "eslint-plugin-import": "^2.25.4",
+    "eslint-plugin-prettier": "^3.1.3",
+    "prettier": "^1.19.1"
   },
   "repository": {
     "type": "git",

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -16,7 +16,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.21.5",
-    "eslint-plugin-react-hooks": "^4.2.1",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-react-native": "^3.11.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "prettier": "^1.19.1"

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -11,15 +11,15 @@
     "eslint-config-airbnb": "18.2.1"
   },
   "peerDependencies": {
-    "eslint": "6.8.0",
-    "eslint-plugin-import": "2.24.2",
-    "eslint-plugin-jsx-a11y": "6.4.1",
-    "eslint-plugin-prettier": "3.1.3",
-    "eslint-plugin-react": "7.21.5",
-    "eslint-plugin-react-hooks": "4.2.1",
-    "eslint-plugin-react-native": "3.11.0",
-    "eslint-plugin-simple-import-sort": "7.0.0",
-    "prettier": "1.19.1"
+    "eslint": "^6.8.0",
+    "eslint-plugin-import": "^2.24.2",
+    "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-prettier": "^3.1.3",
+    "eslint-plugin-react": "^7.21.5",
+    "eslint-plugin-react-hooks": "^4.2.1",
+    "eslint-plugin-react-native": "^3.11.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
+    "prettier": "^1.19.1"
   },
   "repository": {
     "type": "git",

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -10,14 +10,14 @@
     "eslint-config-airbnb": "18.2.1"
   },
   "peerDependencies": {
-    "eslint": "6.8.0",
-    "eslint-plugin-import": "2.24.2",
-    "eslint-plugin-jsx-a11y": "6.4.1",
-    "eslint-plugin-prettier": "3.1.3",
-    "eslint-plugin-react": "7.21.5",
-    "eslint-plugin-react-hooks": "4.2.1",
-    "eslint-plugin-simple-import-sort": "7.0.0",
-    "prettier": "1.19.1"
+    "eslint": "^6.8.0",
+    "eslint-plugin-import": "^2.24.2",
+    "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-prettier": "^3.1.3",
+    "eslint-plugin-react": "^7.21.5",
+    "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
+    "prettier": "^1.19.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I ran into issues trying to get our linter to work on Node 16 with other packages due to the `peerDependencies` being too strict, as well as `eslint-plugin-react-hooks` requiring a specific version that didn't exist according to NPM.

This PR resolves both issues by setting `eslint-plugin-react-hooks` peer dep to `^4.2.0` as well as adding `^` to all `peerDependencies`.